### PR TITLE
Update git submodule url of 'libevdev'

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libevdev"]
 	path = jni/vendor/libevdev/source
-	url = git://anongit.freedesktop.org/libevdev
+	url = https://gitlab.freedesktop.org/libevdev/libevdev.git


### PR DESCRIPTION
This Pull Request updates the URL for the `libevdev` submodule. The previous URL `git://anongit.freedesktop.org/libevdev` is no longer available, and the submodule has been moved to a new location.

Please review the changes and provide feedback.