### PR TITLE
Align LOAD segments to 16 KB for Android 15+ page size support

### DIFF
--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -3,3 +3,7 @@ APP_ABI := all
 # Disable PIE for SDK <16 support. Enable manually for >=5.0
 # where necessary.
 APP_PIE := false
+
+# Align LOAD segments to 16 KB so that the binaries also load on Android
+# 15+ devices with 16 KB page sizes. Harmless on 4 KB devices.
+APP_LDFLAGS += -Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384


### PR DESCRIPTION
minitouch binaries do not load on Android 15+ devices that use 16 KB memory pages. Android 15 added support for those devices ([docs](https://developer.android.com/guide/practices/page-sizes)), and the loader there refuses an ELF whose LOAD segments are 4 KB aligned, so a pushed minitouch exits the instant it is executed. This is only going to get more common: the newer emulator system images we run come only in a 16 KB page size variant, and per the same doc Google Play requires 16 KB support for apps targeting API 35+ from February 1, 2027.

The currently published prebuilts are all 4 KB aligned. From `@devicefarmer/minitouch-prebuilt@1.3.0`:

```
prebuilt/arm64-v8a/bin/minitouch          LOAD p_align: 0x1000
prebuilt/arm64-v8a/bin/minitouch-nopie    LOAD p_align: 0x1000
prebuilt/armeabi-v7a/bin/minitouch        LOAD p_align: 0x1000
prebuilt/armeabi-v7a/bin/minitouch-nopie  LOAD p_align: 0x1000
prebuilt/x86_64/bin/minitouch             LOAD p_align: 0x1000
prebuilt/x86_64/bin/minitouch-nopie       LOAD p_align: 0x1000
prebuilt/x86/bin/minitouch                LOAD p_align: 0x1000
prebuilt/x86/bin/minitouch-nopie          LOAD p_align: 0x1000
```

This adds the two alignment flags Google documents for NDK r27 and lower.

### LOAD p_align, before and after, built with NDK r29

| ABI | master | this PR |
|---|---|---|
| arm64-v8a | 0x4000 | 0x4000 |
| x86_64 | 0x4000 | 0x4000 |
| armeabi-v7a | 0x1000 | 0x4000 |
| x86 | 0x1000 | 0x4000 |

No size cost either. Every binary comes out at an identical file size with and without the flags, on all four ABIs.

r29 already defaults to 16 KB for the 64 bit ABIs, so half of that table looks like a no-op today. Two reasons it is not:

1. The 32 bit ABIs still default to 4 KB even on r29, measured above.
2. Your CI pins `ndk;26.3.11579264`, and 16 KB alignment only became the NDK default in r28. That matches what the published prebuilts above look like.

To confirm the flags are what drives this rather than some toolchain default, I put `max-page-size=4096` in the same place and got `p_align` 0x1000 on every ABI including arm64-v8a and x86_64. The `Application.mk` line is what controls it.

## Verification

Built all four ABIs with NDK r29 (29.0.14206865):

```
$NDK/ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=jni/Android.mk \
  NDK_APPLICATION_MK=jni/Application.mk \
  APP_ABI="arm64-v8a x86_64 armeabi-v7a x86" APP_PLATFORM=android-24 APP_PIE=true
```

Clean build, no new warnings, and all 8 outputs (`minitouch` and `minitouch-nopie` per ABI) come out at `p_align` 0x4000.

Where I hit this concretely was minirev rather than minitouch, on a 16 KB emulator image (`sdk_gphone16k_x86_64`) driven by STF. Same root cause and same one line fix, so I am sending it here too. The minirev side is DeviceFarmer/minirev#2. Runtime checking was on x86_64 only, I have not tested a physical arm64 16 KB device.

One thing I could not check: your CI runs NDK r26, which I cannot run locally, so I have not confirmed that linker accepts `-z common-page-size`. All I can say is that it costs nothing on r29 and it is what the Google doc recommends for r27 and lower.

No prebuilt binaries in this PR, only the build flags. You will want to regenerate the prebuilts to actually ship the fix.
