### PR TITLE
Pick the touch device deterministically instead of relying on readdir order

### DIFF
--- a/jni/minitouch/minitouch.c
+++ b/jni/minitouch/minitouch.c
@@ -2,6 +2,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
+#include <limits.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -218,31 +219,64 @@ mismatch:
   return 0;
 }
 
+// Order /dev/input/eventN numerically, so that event2 comes before event10.
+// alphasort() would not, and the order matters because consider_device()
+// keeps the incumbent when scores tie. Entries that are not eventN sort
+// last, they never win a tie anyway.
+static int event_index(const char* name)
+{
+  const char* num = strstr(name, "event");
+
+  return num == NULL ? INT_MAX : atoi(num + 5);
+}
+
+static int compare_event_nodes(const struct dirent** a, const struct dirent** b)
+{
+  int index_a = event_index((*a)->d_name);
+  int index_b = event_index((*b)->d_name);
+
+  if (index_a != index_b)
+  {
+    return index_a < index_b ? -1 : 1;
+  }
+
+  return strcmp((*a)->d_name, (*b)->d_name);
+}
+
 static int walk_devices(const char* path, internal_state_t* state)
 {
-  DIR* dir;
-  struct dirent* ent;
+  struct dirent** namelist;
   char devpath[FILENAME_MAX];
+  int count;
+  int i;
 
-  if ((dir = opendir(path)) == NULL)
+  // scandir() rather than readdir(), because readdir() returns entries in
+  // filesystem order. Several touch devices can score the same, and since
+  // consider_device() keeps the incumbent on a tie, an unordered walk lets
+  // the kernel decide which touch device we end up using. Emulators expose
+  // one virtio_input_multi_touch_N per possible display, all scoring alike,
+  // so the walk can settle on a display that does not exist and silently
+  // swallow every event. Visiting them in order picks the lowest numbered,
+  // that is the primary display's, device instead.
+  if ((count = scandir(path, &namelist, NULL, compare_event_nodes)) < 0)
   {
-    perror("opendir");
+    perror("scandir");
     return -1;
   }
 
-  while ((ent = readdir(dir)) != NULL)
+  for (i = 0; i < count; i++)
   {
-    if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0)
+    if (strcmp(namelist[i]->d_name, ".") != 0 && strcmp(namelist[i]->d_name, "..") != 0)
     {
-      continue;
+      snprintf(devpath, FILENAME_MAX, "%s/%s", path, namelist[i]->d_name);
+
+      consider_device(devpath, state);
     }
 
-    snprintf(devpath, FILENAME_MAX, "%s/%s", path, ent->d_name);
-
-    consider_device(devpath, state);
+    free(namelist[i]);
   }
 
-  closedir(dir);
+  free(namelist);
 
   return 0;
 }


### PR DESCRIPTION
Which touch device autodetect picks is currently decided by the kernel, not by minitouch.

`walk_devices()` enumerates `/dev/input` with `opendir()`/`readdir()`, and readdir returns entries in filesystem order, not sorted. `consider_device()` keeps the incumbent when scores tie:

```c
if (state->score >= score) goto mismatch;
```

So when several touch devices score identically, the winner is whichever one readdir happened to hand back first. That is arbitrary, and it changes between kernels and system images.

The bad part is that it fails silently. minitouch still prints its normal handshake, the socket accepts connections, every command is acknowledged, and nothing at all happens on screen. Nothing in the output says "I picked a device that is not your screen".

## Where I hit it

Android emulators expose one `virtio_input_multi_touch_N` device per possible display. On an API 37 arm64 image that is 11 of them, `virtio_input_multi_touch_1` on `/dev/input/event1` through `virtio_input_multi_touch_11` on `event11`, and they all score exactly 43762. Only the first one is a display that actually exists.

On that image readdir lists `event11` first, so minitouch settles on `virtio_input_multi_touch_11` and every injected tap and swipe is swallowed. Android 15 and Android 16 images happen to land on `virtio_input_multi_touch_1` and work fine. Same binary, same code, different luck.

Confirmed it is device selection and nothing else. Taking the **unpatched** master build and only adding `-d /dev/input/event1`, the exact same swipe script that did nothing under autodetect opened the app drawer. Android's own `input tap` also worked throughout, so the guest was healthy.

## Before and after

Built from master and from this branch with NDK r29, arm64-v8a, run on the same emulator a few seconds apart:

master:
```
Note: device /dev/input/event10 was outscored by /dev/input/event11 (43762 >= 43762)
Note: device /dev/input/event9 was outscored by /dev/input/event11 (43762 >= 43762)
...
Note: device /dev/input/event1 was outscored by /dev/input/event11 (43762 >= 43762)
Type B touch device virtio_input_multi_touch_11 (32767x32767 with 11 contacts) detected on /dev/input/event11 (score 43762)
```

this PR:
```
Note: device /dev/input/event2 was outscored by /dev/input/event1 (43762 >= 43762)
Note: device /dev/input/event3 was outscored by /dev/input/event1 (43762 >= 43762)
...
Note: device /dev/input/event11 was outscored by /dev/input/event1 (43762 >= 43762)
Type B touch device virtio_input_multi_touch_1 (32767x32767 with 11 contacts) detected on /dev/input/event1 (score 43762)
```

The master listing is the bug in one line. `event11` is the incumbent from the very first comparison, which means readdir returned it first, and the tie rule then protected it for the rest of the walk.

Functionally, feeding the identical swipe script to both binaries from the same home screen: the master build changed nothing on screen, the patched build opened the app drawer. Three runs, one variable each time, and the drawer opens in exactly the two cases where the chosen device is `event1`.

## The fix

`scandir()` with an explicit comparator, so `eventN` is visited in ascending numeric order. Combined with the existing keep-the-incumbent tie rule, the lowest numbered device wins, which is the primary display's.

Numeric and not `alphasort()` on purpose. alphasort is strcmp, so it puts `event10` and `event11` before `event2`, which on this emulator would have kept exactly the same broken choice. Entries that do not match `eventN` sort last via `INT_MAX`. In practice those are things like `mice` and `mouse0` that fail libevdev init and get skipped anyway, so their position does not matter, but worth mentioning since it is a visible ordering change.

This does not add a new heuristic or change any score. It just removes the luck. The scoring in `consider_device()` already goes out of its way to handle devices with more than one touch surface, Blackberry keypads, the Meizu Pro7 Plus sub screen, `sec_touchscreen_side`, and those all rely on the tie rule doing something predictable. Right now, if a heuristic ends in a tie, which device wins is undefined. After this it is defined.

## Verification

```
$NDK/ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=jni/Android.mk \
  APP_ABI=arm64-v8a APP_PLATFORM=android-24 APP_PIE=true NDK_APPLICATION_MK=/dev/null
```

Clean build, no new warnings. Tested on an arm64 API 37 emulator, which is where the failure reproduces. I have not tested a physical device with more than one touch surface, so a second pair of eyes from someone with a Blackberry PRIV or a Pro7 Plus would be welcome, though the change cannot make those worse than undefined.

Separate from #24, which is a build flag change and touches no source.
