### PR TITLE
Build with NDK 29 so binaries load on Android 13 and 14

### DIFF
--- a/.semaphore/deploy_npmjs.yml
+++ b/.semaphore/deploy_npmjs.yml
@@ -19,8 +19,8 @@ blocks:
             - unzip ~/android-commandline-tools.zip -d ~/android-sdk/cmdline-tools/
             - mv ~/android-sdk/cmdline-tools/cmdline-tools/ ~/android-sdk/cmdline-tools/latest
             - export PATH=$PATH:~/android-sdk/cmdline-tools/latest/bin
-            - yes | sdkmanager "ndk;26.3.11579264"
-            - export PATH=$PATH:~/android-sdk/ndk/26.3.11579264/
+            - yes | sdkmanager "ndk;29.0.14206865"
+            - export PATH=$PATH:~/android-sdk/ndk/29.0.14206865/
             - sem-version node 12
             - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
             - npm install

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -19,8 +19,8 @@ blocks:
             - unzip ~/android-commandline-tools.zip -d ~/android-sdk/cmdline-tools/
             - mv ~/android-sdk/cmdline-tools/cmdline-tools/ ~/android-sdk/cmdline-tools/latest
             - export PATH=$PATH:~/android-sdk/cmdline-tools/latest/bin
-            - yes | sdkmanager "ndk;26.3.11579264"
-            - export PATH=$PATH:~/android-sdk/ndk/26.3.11579264/
+            - yes | sdkmanager "ndk;29.0.14206865"
+            - export PATH=$PATH:~/android-sdk/ndk/29.0.14206865/
             - sem-version node 12
             - cache restore
             - npm install


### PR DESCRIPTION
`minitouch-prebuilt` 1.3.1 does not load on Android 13 and 14:

```
minitouch says: "CANNOT LINK EXECUTABLE "/data/local/tmp/minitouch":
can't enable GNU RELRO protection for "/data/local/tmp/minitouch": Out of memory"
```

The device registers in STF and then sits at `Preparing` with no touch. I introduced this in #24,
and I'm sorry about that — it is live for anyone on API 33/34, since stf resolves `^1.3.1`.

## Cause

`PT_GNU_RELRO` ends up larger than the writable `LOAD` segment that backs it, so on a 4 KB-page
device bionic's `mprotect` runs off the end of the mapping and returns `ENOMEM`. In the published
1.3.1 x86_64 binary the writable LOAD is `0x3b8` bytes while RELRO is `0x1ea0`.

This is specific to the NDK pinned here (26.3.11579264). Newer toolchains size the writable LOAD to
cover the RELRO padding. Checking whether RELRO stays inside a mapped LOAD, from the program
headers:

| minitouch x86_64 | 4 KB page | 16 KB page |
|---|---|---|
| NDK 26 (current pin) | **OVERRUNS** | FITS |
| NDK 29 | FITS | FITS |

API 35+ tolerates the overrun, which is why 1.3.1 looked fine on newer devices and why this got
through review — my own validation used NDK 29 without realising CI pinned 26.

## Change

Bump the NDK in `.semaphore/semaphore.yml` and `.semaphore/deploy_npmjs.yml` from
`26.3.11579264` to `29.0.14206865` — the same version minirev moved to in DeviceFarmer/minirev#3.
No source or flag changes.

## Verification

Built with NDK 29.0.14206865 in an `ubuntu:22.04` container replicating the Semaphore job, then run
on a real STF farm: one emulator per Android version, on two different STF branches, 9 runs total.
Touch was driven through the STF web UI with Playwright and confirmed by the streamed screen
actually changing.

| Android | API | served | input node | linker errors | touch via UI |
|---|---|---|---|---|---|
| 13 | 33 | yes (x2) | event2 | 0 | works |
| 14 | 34 | yes (x2) | event2 | 0 | works |
| 15 | 35 | yes (x2) | event2 | 0 | works |
| 16 | 36 | yes (x2) | event2 | 0 | works |
| 17 | 37 | yes | event2 | 0 | works |

Android 17 uses `system-images;android-37.2-beta3;google_apis_ps16k;x86_64`, a 16 KB-page image, so
16 KB support is retained — that was the point of #24 and it still holds. Every run selected
`/dev/input/event2`, so #25's device selection is unaffected.

For contrast, the same Android 13/14 runs on 1.3.1 produced the `CANNOT LINK` error above and never
became usable.

## Why this matters

Touch is not an optional extra in STF — a device that cannot start minitouch never leaves
`Preparing`, so it is unusable even though it appears in the device list and looks healthy. Android
13 and 14 are still a large share of real fleets, and stf resolves `@devicefarmer/minitouch-prebuilt`
with `^1.3.1`, so a fresh install picks up the broken binary automatically. The failure is also
silent from the outside: the only clue is the linker message in the device worker log.

Also, #24's commit message describes the alignment as "Harmless on 4 KB devices". That turned out to
be wrong, and this is the counterexample — happy to word a correction however you prefer.
